### PR TITLE
feat: support VOICEVOX_API_URL env var for custom endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ MCP (Model Context Protocol) を通じて VOICEVOX のテキスト読み上げ�
 - **VOICEVOX エンジンが起動している必要があります**
   - [VOICEVOX 公式サイト](https://voicevox.hiroshiba.jp/)から VOICEVOX をダウンロード・インストール
   - VOICEVOX を起動し、エンジンが `http://localhost:50021` で稼働していることを確認
+  - 別のホストで稼働している VOICEVOX エンジンを使用する場合は、環境変数 `VOICEVOX_API_URL` でエンドポイントを指定できます（例: `http://your-server:50021`）
 
 ## インストール
 
@@ -61,6 +62,16 @@ npm start
 ### MCP クライアントから利用
 
 MCP クライアント（Claude Code 等）で以下のツールが利用できます。
+
+#### Claude Code での設定例
+
+```bash
+# 基本（ローカルの VOICEVOX エンジンを使用）
+claude mcp add voicevox -- npx @t09tanaka/mcp-simple-voicevox
+
+# リモートの VOICEVOX エンジンを使用する場合
+claude mcp add voicevox -e VOICEVOX_API_URL=http://your-server:50021 -- npx @t09tanaka/mcp-simple-voicevox
+```
 
 **設定方法の詳細は [docs/usage.md](docs/usage.md) を参照してください。**
 
@@ -134,6 +145,7 @@ npm test
 
 - VOICEVOX アプリケーションが起動しているか確認
 - `http://localhost:50021` で VOICEVOX API が利用可能か確認
+- `VOICEVOX_API_URL` を設定している場合は、指定したエンドポイントが正しいか確認
 - ファイアウォールの設定を確認
 
 ### 音声が再生されない

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -21,6 +21,31 @@ Claude CodeでMCP-VOICEVOXサーバーを使用するには、設定ファイル
 }
 ```
 
+リモートの VOICEVOX エンジンを使用する場合は、`env` で `VOICEVOX_API_URL` を指定します：
+
+```json
+{
+  "mcpServers": {
+    "voicevox": {
+      "command": "npx",
+      "args": ["@t09tanaka/mcp-simple-voicevox"],
+      "env": {
+        "VOICEVOX_API_URL": "http://your-server:50021"
+      }
+    }
+  }
+}
+```
+
+Claude Code CLI からの登録例：
+
+```bash
+claude mcp add voicevox -- npx @t09tanaka/mcp-simple-voicevox
+
+# 環境変数付き
+claude mcp add voicevox -e VOICEVOX_API_URL=http://your-server:50021 -- npx @t09tanaka/mcp-simple-voicevox
+```
+
 #### 方法2: 直接パス指定
 
 ##### macOS/Linux の場合

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,8 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import { VoicevoxClient } from './voicevox-client.js';
 
-const VOICEVOX_ENDPOINT = 'http://localhost:50021';
+const VOICEVOX_ENDPOINT =
+  process.env.VOICEVOX_API_URL ?? 'http://localhost:50021';
 
 class VoicevoxMCPServer {
   private server: Server;


### PR DESCRIPTION
## Summary

- Support configuring the VOICEVOX engine endpoint via the `VOICEVOX_API_URL` environment variable
- Falls back to `http://localhost:50021` when the variable is not set (no breaking change)
- Update README and docs with usage instructions including `claude mcp add` examples

## Motivation

When running VOICEVOX engine on a remote host (e.g., a Docker container on another machine), the hardcoded `http://localhost:50021` endpoint prevents connection. This change allows users to specify a custom endpoint via environment variable.

## Changes

| File | Change |
|------|--------|
| `src/index.ts` | Read endpoint from `process.env.VOICEVOX_API_URL` with localhost fallback |
| `README.md` | Add env var description, Claude Code CLI examples, troubleshooting note |
| `docs/usage.md` | Add MCP config JSON with `env` field and CLI registration examples |

## Usage Example

```bash
# Basic
claude mcp add voicevox -- npx @t09tanaka/mcp-simple-voicevox

# With remote VOICEVOX engine
claude mcp add voicevox -e VOICEVOX_API_URL=http://your-server:50021 -- npx @t09tanaka/mcp-simple-voicevox
```